### PR TITLE
Servicemodulefix

### DIFF
--- a/aurora.dme
+++ b/aurora.dme
@@ -43,7 +43,6 @@
 #define FILE_DIR "icons/obj/flora"
 #define FILE_DIR "icons/obj/machines"
 #define FILE_DIR "icons/obj/pipes"
-#define FILE_DIR "icons/obj/reactor"
 #define FILE_DIR "icons/pda_icons"
 #define FILE_DIR "icons/spideros_icons"
 #define FILE_DIR "icons/Testing"

--- a/aurora.dme
+++ b/aurora.dme
@@ -43,6 +43,7 @@
 #define FILE_DIR "icons/obj/flora"
 #define FILE_DIR "icons/obj/machines"
 #define FILE_DIR "icons/obj/pipes"
+#define FILE_DIR "icons/obj/reactor"
 #define FILE_DIR "icons/pda_icons"
 #define FILE_DIR "icons/spideros_icons"
 #define FILE_DIR "icons/Testing"

--- a/code/game/objects/items/weapons/RSF.dm
+++ b/code/game/objects/items/weapons/RSF.dm
@@ -1,116 +1,366 @@
+//Reworked and refactored by Pixelnator on 20.3.2014 to support printing items directly into peoples hands provided they accept the give prompt.
+//Updated by Pixelnator on 12.8.2015 to work with Unity2.0 code.
+
 /*
 CONTAINS:
 RSF
-
 */
-
 /obj/item/weapon/rsf
-	name = "\improper Rapid-Service-Fabricator"
+	name = "rapid-service-fabricator (RSF)"
 	desc = "A device used to rapidly deploy service items."
 	icon = 'icons/obj/items.dmi'
 	icon_state = "rcd"
 	opacity = 0
 	density = 0
 	anchored = 0.0
-	var/stored_matter = 30
-	var/mode = 1
-	flags = TABLEPASS
+	flags = FPRINT | TABLEPASS| CONDUCT
+	force = 10.0
+	throwforce = 10.0
+	throw_speed = 1
+	throw_range = 5
 	w_class = 3.0
+	matter = list("metal" = 50000)
+	origin_tech = "engineering=2;materials=1"
+	var/stored_matter = 0
+	var/working = 0
+	var/mode = 1
+	var/setting = "Dosh"
+	var/disabled = 0
 
-/obj/item/weapon/rsf/examine()
-	set src in view(1)
-	..()
-	usr << "It currently holds [stored_matter]/30 fabrication-units."
+	New()
+		desc = "An RSF. It currently holds [stored_matter]/30 fabrication-units."
+		return
 
-/obj/item/weapon/rsf/attackby(obj/item/weapon/W as obj, mob/user as mob)
-	..()
-	if (istype(W, /obj/item/weapon/rcd_ammo))
-
-		if ((stored_matter + 10) > 30)
-			user << "The RSF can't hold any more matter."
+	attackby(obj/item/weapon/W, mob/user)
+		..()
+		if(istype(W, /obj/item/weapon/rcd_ammo))
+			if((stored_matter + 10) > 30)
+				user << "<span class='notice'>The RSF cant hold any more matter-units.</span>"
+				return
+			user.drop_item()
+			del(W)
+			stored_matter += 10
+			playsound(src.loc, 'sound/machines/click.ogg', 10, 1)
+			user << "<span class='notice'>The RSF now holds [stored_matter]/30 matter-units.</span>"
+			desc = "An RSF. It currently holds [stored_matter]/30 matter-units."
 			return
 
-		del(W)
+	attack_self(mob/user as mob)
+		//Change the mode - I could probably add sparks here but I don't think the fabber is heavy duty enough
+		playsound(src.loc, 'sound/effects/pop.ogg', 50, 0)
+		switch(mode)
+			if (1)
+				mode = 2
+				setting = "Drinking Glass"
+				printsetting()
+				return
+			if (2)
+				mode = 3
+				setting = "Paper"
+				printsetting()
+				return
+			if (3)
+				mode = 4
+				setting = "Pen"
+				printsetting()
+				return
+			if (4)
+				mode = 5
+				setting = "Dice Pack"
+				printsetting()
+				return
+			if (5)
+				mode = 6
+				setting = "Cigarette"
+				printsetting()
+				return
+			if (6)
+				mode = 1
+				setting = "Dosh"
+				printsetting()
+				return
 
-		stored_matter += 10
+	proc/activate()
 		playsound(src.loc, 'sound/machines/click.ogg', 10, 1)
-		user << "The RSF now holds [stored_matter]/30 fabrication-units."
-		return
 
-/obj/item/weapon/rsf/attack_self(mob/user as mob)
-	playsound(src.loc, 'sound/effects/pop.ogg', 50, 0)
-	if (mode == 1)
-		mode = 2
-		user << "Changed dispensing mode to 'Drinking Glass'"
-		return
-	if (mode == 2)
-		mode = 3
-		user << "Changed dispensing mode to 'Paper'"
-		return
-	if (mode == 3)
-		mode = 4
-		user << "Changed dispensing mode to 'Pen'"
-		return
-	if (mode == 4)
-		mode = 5
-		user << "Changed dispensing mode to 'Dice Pack'"
-		return
-	if (mode == 5)
-		mode = 6
-		user << "Changed dispensing mode to 'Cigarette'"
-		return
-	if (mode == 6)
-		mode = 1
-		user << "Changed dispensing mode to 'Dosh'"
-		return
-	// Change mode
+	proc/printsetting()
+		usr << "<span class='notice'>Changed dispensing mode to '[setting]'</span>"
 
-/obj/item/weapon/rsf/afterattack(atom/A, mob/user as mob, proximity)
+	proc/printmessage()
+		usr << "Dispensing [setting]..."
 
-	if(!proximity) return
 
-	if(istype(user,/mob/living/silicon/robot))
-		var/mob/living/silicon/robot/R = user
-		if(R.stat || !R.cell || R.cell.charge <= 0)
+	afterattack(atom/A, mob/user as mob, proximity)
+		if(!proximity) return
+		if(disabled && !isrobot(user)) //Disabled RSFs don't work unless you're a borg
+			return 0
+		if (!(istype(A,/obj/structure/table) || istype(A,/turf/simulated/floor) || istype(A,/turf/unsimulated/floor))) //Unsimulated floors are supported if service borgs go on away missions
+			return 0
+
+		switch(mode)
+			if(1)
+				if(useResource(10, user))
+					printmessage()
+					activate()
+					if(istype(A, /turf/simulated/floor))
+						new /obj/item/weapon/spacecash/c10( A )
+					if(istype(A, /obj/structure/table))
+						new /obj/item/weapon/spacecash/c10( A.loc )
+					return 1
+				return 0
+
+			if(2)
+				if(useResource(2, user))
+					printmessage()
+					activate()
+					if(istype(A, /turf/simulated/floor))
+						new /obj/item/weapon/reagent_containers/food/drinks/drinkingglass( A )
+					if(istype(A, /obj/structure/table))
+						new /obj/item/weapon/reagent_containers/food/drinks/drinkingglass( A.loc )
+					return 1
+				return 0
+
+			if(3)
+				if(useResource(1, user))
+					printmessage()
+					activate()
+					if(istype(A, /turf/simulated/floor))
+						new /obj/item/weapon/paper( A )
+					if(istype(A, /obj/structure/table))
+						new /obj/item/weapon/paper( A.loc )
+					return 1
+				return 0
+
+			if(4)
+				if(useResource(2, user))
+					printmessage()
+					activate()
+					if(istype(A, /turf/simulated/floor))
+						new /obj/item/weapon/pen( A )
+					if(istype(A,/obj/structure/table))
+						new /obj/item/weapon/pen( A.loc )
+					return 1
+				return 0
+
+			if(5)
+				if(useResource(10, user))
+					printmessage()
+					activate()
+					if(istype(A, /turf/simulated/floor))
+						new /obj/item/weapon/storage/pill_bottle/dice( A )
+					if(istype(A,/obj/structure/table))
+						new /obj/item/weapon/storage/pill_bottle/dice( A.loc )
+					return 1
+				return 0
+
+			if(6)
+				if(useResource(1, user))
+					printmessage()
+					activate()
+					if(istype(A, /turf/simulated/floor))
+						new /obj/item/clothing/mask/cigarette( A )
+					if(istype(A,/obj/structure/table))
+						new /obj/item/clothing/mask/cigarette( A.loc )
+					return 1
+				return 0
+			else
+				user << "ERROR: RSF in MODE: [mode] attempted use by [user]. Send this text to an admin."
+				return 0
+
+	attack(mob/M as mob, mob/user as mob)
+		if (istype(M, /mob/living/carbon/human) && M != usr) //Only give items to humanoid characters and only if you're giving it to someone else.
+			if (checkResource(1, user)) //Only give the prompt if the RSF has ammo or the borg has battery
+				switch(alert(M,"[usr] wants to print you \a [setting]?",,"Yes","No"))
+					if("Yes")
+						switch(mode)
+							if (1)
+								if(!Adjacent(usr))
+									usr << "You need to keep in reaching distance."
+									M << "[usr.name] moved too far away."
+									return
+								if(M.r_hand != null)
+									if(M.l_hand == null)
+										if (useResource(10, user))
+											M.put_in_l_hand(new /obj/item/weapon/spacecash/c10(M))
+											printmessage()
+											activate()
+											return 1
+										return 0
+
+									else
+										M << "Your hands are full."
+										usr << "Their hands are full."
+										return
+								else
+									if (useResource(10, user))
+										M.put_in_r_hand(new /obj/item/weapon/spacecash/c10(M))
+										printmessage()
+										activate()
+										return 1
+									return 0
+								return 0
+							if (2)
+								if(!Adjacent(usr))
+									usr << "You need to keep in reaching distance."
+									M << "[usr.name] moved too far away."
+									return
+								if(M.r_hand != null)
+									if(M.l_hand == null)
+										if (useResource(10, user))
+											M.put_in_l_hand(new /obj/item/weapon/reagent_containers/food/drinks/drinkingglass(M))
+											printmessage()
+											activate()
+											return 1
+										return 0
+
+									else
+										M << "Your hands are full."
+										usr << "Their hands are full."
+										return
+								else
+									if (useResource(10, user))
+										M.put_in_r_hand(new /obj/item/weapon/reagent_containers/food/drinks/drinkingglass(M))
+										printmessage()
+										activate()
+										return 1
+									return 0
+								return 0
+							if (3)
+								if(!Adjacent(usr))
+									usr << "You need to keep in reaching distance."
+									M << "[usr.name] moved too far away."
+									return
+								if(M.r_hand != null)
+									if(M.l_hand == null)
+										if (useResource(10, user))
+											M.put_in_l_hand(new /obj/item/weapon/paper(M))
+											printmessage()
+											activate()
+											return 1
+										return 0
+
+									else
+										M << "Your hands are full."
+										usr << "Their hands are full."
+										return
+								else
+									if (useResource(10, user))
+										M.put_in_r_hand(new /obj/item/weapon/paper(M))
+										printmessage()
+										activate()
+										return 1
+									return 0
+								return 0
+							if (4)
+								if(!Adjacent(usr))
+									usr << "You need to keep in reaching distance."
+									M << "[usr.name] moved too far away."
+									return
+								if(M.r_hand != null)
+									if(M.l_hand == null)
+										if (useResource(10, user))
+											M.put_in_l_hand(new /obj/item/weapon/pen(M))
+											printmessage()
+											activate()
+											return 1
+										return 0
+
+									else
+										M << "Your hands are full."
+										usr << "Their hands are full."
+										return
+								else
+									if (useResource(10, user))
+										M.put_in_r_hand(new /obj/item/weapon/pen(M))
+										printmessage()
+										activate()
+										return 1
+									return 0
+								return 0
+							if (5)
+								if(!Adjacent(usr))
+									usr << "You need to keep in reaching distance."
+									M << "[usr.name] moved too far away."
+									return
+								if(M.r_hand != null)
+									if(M.l_hand == null)
+										if (useResource(10, user))
+											M.put_in_l_hand(new /obj/item/weapon/storage/pill_bottle/dice(M))
+											printmessage()
+											activate()
+											return 1
+										return 0
+
+									else
+										M << "Your hands are full."
+										usr << "Their hands are full."
+										return
+								else
+									if (useResource(10, user))
+										M.put_in_r_hand(new /obj/item/weapon/storage/pill_bottle/dice(M))
+										printmessage()
+										activate()
+										return 1
+									return 0
+								return 0
+							if (6)
+								if(!Adjacent(usr))
+									usr << "You need to keep in reaching distance."
+									M << "[usr.name] moved too far away."
+									return
+								if(M.r_hand != null)
+									if(M.l_hand == null)
+										if (useResource(10, user))
+											M.put_in_l_hand(new /obj/item/clothing/mask/cigarette(M))
+											printmessage()
+											activate()
+											return 1
+										return 0
+
+									else
+										M << "Your hands are full."
+										usr << "Their hands are full."
+										return
+								else
+									if (useResource(10, user))
+										M.put_in_r_hand(new /obj/item/clothing/mask/cigarette(M))
+										printmessage()
+										activate()
+										return 1
+									return 0
+								return 0
+							else
+								user << "ERROR: RSF in MODE: [mode] attempted use by [user]. Send this text to an admin."
+								return 0
+						return
+
+					if("No")
+						M.visible_message("[usr.name] tried to print [setting] to [M.name] but [M.name] didn't want it.")
+						return
+
+
 			return
-	else
-		if(stored_matter <= 0)
-			return
 
-	if(!istype(A, /obj/structure/table) && !istype(A, /turf/simulated/floor))
-		return
+/obj/item/weapon/rsf/proc/useResource(var/amount, var/mob/user)
+	if(stored_matter < amount)
+		return 0
+	stored_matter -= amount
+	desc = "An RSF. It currently holds [stored_matter]/30 matter-units."
+	return 1
 
-	playsound(src.loc, 'sound/machines/click.ogg', 10, 1)
-	var/used_energy = 0
-	var/obj/product
+/obj/item/weapon/rsf/proc/checkResource(var/amount, var/mob/user)
+	return stored_matter >= amount
 
-	switch(mode)
-		if(1)
-			product = new /obj/item/weapon/spacecash/c10()
-			used_energy = 200
-		if(2)
-			product = new /obj/item/weapon/reagent_containers/food/drinks/drinkingglass()
-			used_energy = 50
-		if(3)
-			product = new /obj/item/weapon/paper()
-			used_energy = 10
-		if(4)
-			product = new /obj/item/weapon/pen()
-			used_energy = 50
-		if(5)
-			product = new /obj/item/weapon/storage/pill_bottle/dice()
-			used_energy = 200
-		if(6)
-			product = new /obj/item/clothing/mask/cigarette()
-			used_energy = 10
+/obj/item/weapon/rsf/borg/useResource(var/amount, var/mob/user)
+	if(!isrobot(user))
+		return 0
+	return user:cell:use(amount * 30)
 
-	user << "Dispensing [product ? product : "product"]..."
-	product.loc = get_turf(A)
+/obj/item/weapon/rsf/borg/checkResource(var/amount, var/mob/user)
+	if(!isrobot(user))
+		return 0
+	return user:cell:charge >= (amount * 30)
 
-	if(isrobot(user))
-		var/mob/living/silicon/robot/R = user
-		if(R.cell)
-			R.cell.use(used_energy)
-	else
-		stored_matter--
-		user << "The RSF now holds [stored_matter]/30 fabrication-units."
+/obj/item/weapon/rsf/borg/New()
+	..()
+	desc = "A device used to rapidly deploy service items."

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -18,7 +18,7 @@
 	var/obj/screen/inv1 = null
 	var/obj/screen/inv2 = null
 	var/obj/screen/inv3 = null
-	
+
 	var/shown_robot_modules = 0	//Used to determine whether they have the module menu shown or not
 	var/obj/screen/robot_modules_background
 
@@ -79,7 +79,7 @@
 	robot_modules_background = new()
 	robot_modules_background.icon_state = "block"
 	robot_modules_background.layer = 19	//Objects that appear on screen are on layer 20, UI should be just below it.
-	
+
 	ident = rand(1, 999)
 	updatename("Default")
 	updateicon()
@@ -204,13 +204,13 @@
 
 	// languages
 	module.add_languages(src)
-	
-	// cameras 
+
+	// cameras
 	module.add_to_camera_network(src)
-	
+
 	// sensors
 	module.add_sensor_modification(src)
-	
+
 	// create sprite list
 	var/list/module_sprites = module.sprites.Copy()
 
@@ -298,6 +298,21 @@
 	set name = "Show Crew Manifest"
 	show_station_manifest()
 
+// the borg can lock and unlock its own cover. Since we're lowpop you can ask someone else to change your modules/recharge your batteries for you
+/mob/living/silicon/robot/verb/borg_toggle_cover_verb()
+	set category = "Robot Commands"
+	set name = "Toggle Cover Lock"
+	borg_toggle_cover()
+
+/mob/living/silicon/robot/verb/borg_toggle_cover()
+	if(emagged)//emagged covers are permanently unlocked.
+		src << "ERROR: Lock interface failure." //The message is a bit more vague on the borg's side. If someone tries to use their ID they get the "it's broken lol" message.
+	if(opened)
+		src << "ERROR: Lock initialization failure: cover open."
+	else
+		locked = !locked
+		src << "You [ locked ? "lock" : "unlock"] your cover."
+		updateicon()
 
 /mob/living/silicon/robot/proc/robot_alerts()
 	var/dat = "<HEAD><TITLE>Current Station Alerts</TITLE><META HTTP-EQUIV='Refresh' CONTENT='10'></HEAD><BODY>\n"
@@ -373,7 +388,7 @@
 		updatehealth()
 		return 1
 	return 0
-	
+
 /mob/living/silicon/robot/proc/sensor_mode()
 	set name = "Set Sensor Augmentation"
 	set desc = "Augment visual feed with internal sensor overlays."

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -30,8 +30,8 @@
 		src.emag = new /obj/item/toy/sword(src)
 		src.emag.name = "Placeholder Emag Item"
 		return
-		
-		
+
+
 /obj/item/weapon/robot_module/proc/respawn_consumable(var/mob/living/silicon/robot/R)
 
 	if(!stacktypes || !stacktypes.len) return
@@ -58,24 +58,35 @@
 
 /obj/item/weapon/robot_module/proc/add_languages(var/mob/living/silicon/robot/R)
 	//full set of languages
-	R.add_language("Sol Common", 1)
+	R.add_language("Anglic", 1)
 	R.add_language("Tradeband", 0)
-	R.add_language("Sinta'unathi", 0)
-	R.add_language("Siik'Maas", 0)
-	R.add_language("Skrellian", 0)
 	R.add_language("Gutter", 0)
+	R.add_language("Sinta", 0)
+	R.add_language("Uwe", 0)
+	R.add_language("Weis", 0)
+	R.add_language("Rezar", 0)
+	R.add_language("Zawan", 0)
+	R.add_language("Pekhotha sign", 0)
+	R.add_language("Skrellian", 0)
+	R.add_language("Sini", 0)
+	R.add_language("Kida", 0)
 	R.add_language("Rootspeak", 0)
+	R.add_language("Sign language", 0) //yes, the borg knows sign language. If you need to know why it can use it, a space wizard did it.
+	R.add_language("Zho", 0)
+	R.add_language("Ara", 0)
+	R.add_language("Hindi", 0)
+	R.add_language("", 0)
 
 
 /obj/item/weapon/robot_module/proc/add_to_camera_network(var/mob/living/silicon/robot/R)
 	if (camera_network)
 		if(R.camera && "Robots" in R.camera.network)
 			R.camera.network.Add(camera_network)
-	
+
 
 /obj/item/weapon/robot_module/proc/add_sensor_modification(var/mob/living/silicon/robot/R)
 	R.sensor_mode=sensor_mode
-	
+
 
 /obj/item/weapon/robot_module/standard
 	name = "standard robot module"
@@ -323,8 +334,8 @@
 
 /obj/item/weapon/robot_module/butler
 	name = "service robot module"
-	sprites = list( "Waitress" = "Service", 
-					"Kent" = "toiletbot", 
+	sprites = list( "Waitress" = "Service",
+					"Kent" = "toiletbot",
 					"Bro" = "Brobot",
 					"Rich" = "maximillion",
 					"Default" = "Service2")
@@ -335,7 +346,7 @@
 		src.modules += new /obj/item/weapon/reagent_containers/food/condiment/enzyme(src)
 		src.modules += new /obj/item/weapon/pen/robopen(src)
 
-		var/obj/item/weapon/rsf/M = new /obj/item/weapon/rsf(src)
+		var/obj/item/weapon/rsf/M = new /obj/item/weapon/rsf/borg(src)
 		M.stored_matter = 30
 		src.modules += M
 
@@ -368,8 +379,8 @@
 
 /obj/item/weapon/robot_module/clerical
 	name = "clerical robot module"
-	sprites = list( "Waitress" = "Service", 
-					"Kent" = "toiletbot", 
+	sprites = list( "Waitress" = "Service",
+					"Kent" = "toiletbot",
 					"Bro" = "Brobot",
 					"Rich" = "maximillion",
 					"Default" = "Service2")


### PR DESCRIPTION
- Ported over the RSF (Rapid Service Fabricator) from old Unity. (Refactored code and allows borgs to print items into peoples hands similar to the "give" verb)
- Gave borgs a verb to toggle their own cover lock. Handy if you want someone to switch your battery/change your module but they lack access.
- Changed the languages the service module gives you to facilitate the updated languages of the server

The adjacency check on printing items into peoples hands doesn't work and I can't figure out how to fix it. If someone else wants to do it, feel free.
